### PR TITLE
added option to use generic for Transition.params

### DIFF
--- a/src/transition/transition.ts
+++ b/src/transition/transition.ts
@@ -259,7 +259,8 @@ export class Transition implements IHookRegistry {
    *
    * @returns transition parameter values for the desired path.
    */
-  params(pathname: string = "to"): { [key: string]: any } {
+  params<T>(pathname?: string): T;
+  params(pathname: string = "to"): any {
     return this._treeChanges[pathname].map(prop("paramValues")).reduce(mergeR, {});
   }
 

--- a/src/transition/transition.ts
+++ b/src/transition/transition.ts
@@ -259,8 +259,9 @@ export class Transition implements IHookRegistry {
    *
    * @returns transition parameter values for the desired path.
    */
+  params(pathname?: string): any;
   params<T>(pathname?: string): T;
-  params(pathname: string = "to"): any {
+  params(pathname: string = "to") {
     return this._treeChanges[pathname].map(prop("paramValues")).reduce(mergeR, {});
   }
 


### PR DESCRIPTION
Proposed fix for #16. This should not introduce any breaking changes, it should just give you the additional option of specifying  which properties do appear in `.params` (with types).

[Example in typescript playground](https://www.typescriptlang.org/play/#src=interface%20Transition%20%7B%0D%0A%20%20%20%20params(pathname%3F%3A%20string)%3A%20%7B%20%5Bkey%3A%20string%5D%3A%20any%20%7D%3B%0D%0A%0D%0A%20%20%20%20%2F%2F%20Suggested%20addition%2Fchange%0D%0A%20%20%20%20params%3CT%20extends%20%7B%20%5Bkey%3A%20string%5D%3A%20any%20%7D%3E(pathname%3F%3A%20string)%3A%20T%3B%0D%0A%7D%0D%0A%0D%0A%2F%2F%20EXAMPLES%0D%0Ainterface%20MyStateParams%20%7B%0D%0A%20%20%20%20id%3A%20number%3B%0D%0A%20%20%20%20sort%3A%20string%3B%0D%0A%7D%0D%0A%20%20%20%20%0D%0A%2F%2F%20Currently%0D%0A(function%20(t)%20%7B%0D%0A%0D%0A%20%20%20%20let%20toParams%20%3D%20t.params()%3B%0D%0A%0D%0A%20%20%20%20console.log(toParams.id%2C%20toParams.sort)%3B%20%2F%2F%20doh!%0D%0A%0D%0A%20%20%20%20let%20%7B%20id%2C%20sort%20%7D%20%3D%20toParams%3B%20%2F%2F%20closer%2C%20though%20%22id%22%20and%20%22sort%22%20is%20type%20%22any%22%0D%0A%0D%0A%20%20%20%20%2F%2F%20casting%20works%20alright%2C%20but%20makes%20syntax%20more%20unwieldy%20in%20one%20liners%3A%0D%0A%0D%0A%20%20%20%20let%20realToParams%20%3D%20toParams%20as%20MyStateParams%3B%0D%0A%20%20%20%20%0D%0A%20%20%20%20console.log(realToParams.id%2C%20realToParams.sort)%3B%0D%0A%20%20%20%20console.log('id%3A'%2C%20(toParams%20as%20MyStateParams).id)%3B%0D%0A%0D%0A%0D%0A%7D)(%7B%7D%20as%20Transition)%3B%0D%0A%0D%0A%0D%0A%2F%2F%20With%20above%20change%0D%0A(function%20(t)%20%7B%0D%0A%0D%0A%20%20%20%20let%20toParams%20%3D%20t.params%3CMyStateParams%3E()%3B%0D%0A%0D%0A%20%20%20%20console.log(toParams.id%2C%20toParams.sort)%3B%0D%0A%0D%0A%7D)(%7B%7D%20as%20Transition)%3B%0D%0A#src=interface%20Transition%20%7B%0D%0A%20%20%20%20params(pathname%3F%3A%20string)%3A%20%7B%20%5Bkey%3A%20string%5D%3A%20any%20%7D%3B%0D%0A%7D%0D%0A%0D%0A%2F%2F%20Suggested%20change%0D%0Ainterface%20Transition2%20%7B%0D%0A%20%20%20%20params%3CT%3E(pathname%3F%3A%20string)%3A%20T%20%26%20%7B%20%5Bkey%3A%20string%5D%3A%20any%20%7D%3B%0D%0A%7D%0D%0A%0D%0A%2F%2F%20EXAMPLES%0D%0Ainterface%20MyStateParams%20%7B%0D%0A%20%20%20%20id%3A%20number%3B%0D%0A%20%20%20%20sort%3A%20string%3B%0D%0A%7D%0D%0A%0D%0A%0D%0Afunction%20currentUsage(t%3A%20Transition)%20%7B%0D%0A%20%20%20%20let%20toParams%20%3D%20t.params()%3B%0D%0A%0D%0A%20%20%20%20console.log(toParams.id%2C%20toParams.sort)%3B%20%2F%2F%20doh!%0D%0A%20%20%20%20console.log(toParams%5B'id'%5D%2C%20toParams%5B'sort'%5D)%3B%20%2F%2F%20ugly%20workaround%0D%0A%0D%0A%20%20%20%20let%20%7B%20id%2C%20sort%20%7D%20%3D%20toParams%3B%20%2F%2F%20closer%2C%20though%20%22id%22%20and%20%22sort%22%20is%20type%20%22any%22%0D%0A%0D%0A%20%20%20%20%2F%2F%20casting%20works%20alright%2C%20but%20makes%20syntax%20more%20unwieldy%20in%20one%20liners%3A%0D%0A%0D%0A%20%20%20%20let%20realToParams%20%3D%20toParams%20as%20MyStateParams%3B%0D%0A%20%20%20%20%0D%0A%20%20%20%20console.log(realToParams.id%2C%20realToParams.sort)%3B%0D%0A%20%20%20%20console.log('id%3A'%2C%20(toParams%20as%20MyStateParams).id)%3B%0D%0A%7D%0D%0A%0D%0A%0D%0A%2F%2F%20With%20above%20change%0D%0Afunction%20suggestedUsage(t%3A%20Transition2)%20%7B%0D%0A%20%20%20%20let%20toParams%20%3D%20t.params%3CMyStateParams%3E()%3B%0D%0A%0D%0A%20%20%20%20console.log(toParams.id%2C%20toParams.sort)%3B%0D%0A%7D%0D%0A).