### PR TITLE
docs(State): align description of `state.State.includes` with actual implementation

### DIFF
--- a/src/state/stateObject.ts
+++ b/src/state/stateObject.ts
@@ -77,8 +77,11 @@ export class StateObject {
    */
   public data: any;
 
-  /** An array of strings of the parent States' names */
-  public includes: { [name: string] : boolean };
+  /** 
+   * An object containing the parent States' names as keys and 
+   * true as their values.
+   */
+  public includes: { [name: string]: boolean };
 
   /** Prototypally inherits from [[StateDeclaration.onExit]] */
   public onExit: TransitionStateHookFn;


### PR DESCRIPTION
This PR targets [#3356](https://github.com/angular-ui/ui-router/issues/3356) opened up by me.

@christopherthielen 
I did not include an example. I thought it needs even more explanation. Hope the single sentence is clear enough.

Sorry, if I missed something. This is my first PR.