### PR TITLE
Fixed strictNullChecks for HookMatchCriteria

### DIFF
--- a/src/transition/interface.ts
+++ b/src/transition/interface.ts
@@ -761,15 +761,15 @@ export interface HookMatchCriteria {
   [key: string]: HookMatchCriterion;
 
   /** A [[HookMatchCriterion]] to match the destination state */
-  to?: HookMatchCriterion | undefined;
+  to?: HookMatchCriterion;
   /** A [[HookMatchCriterion]] to match the original (from) state */
-  from?: HookMatchCriterion | undefined;
+  from?: HookMatchCriterion;
   /** A [[HookMatchCriterion]] to match any state that would be exiting */
-  exiting?: HookMatchCriterion | undefined;
+  exiting?: HookMatchCriterion;
   /** A [[HookMatchCriterion]] to match any state that would be retained */
-  retained?: HookMatchCriterion | undefined;
+  retained?: HookMatchCriterion;
   /** A [[HookMatchCriterion]] to match any state that would be entering */
-  entering?: HookMatchCriterion | undefined;
+  entering?: HookMatchCriterion;
 }
 
 export interface IMatchingNodes {
@@ -814,7 +814,7 @@ export interface PathType {
  *
  * Or, `true` to always match
  */
-export type HookMatchCriterion = (string|IStateMatch|boolean)
+export type HookMatchCriterion = (string|IStateMatch|boolean|undefined)
 
 export enum TransitionHookPhase { CREATE, BEFORE, RUN, SUCCESS, ERROR }
 export enum TransitionHookScope { TRANSITION, STATE }


### PR DESCRIPTION
**TypeScript version**: `2.3.4`

**TSConfig**:
<details>
<summary>TSConfig</summary>
<pre>
<code>
{
  "compilerOptions": {
    "target": "es2015",
    "module": "es2015",
    "moduleResolution": "node",
    "emitDecoratorMetadata": true,
    "experimentalDecorators": true,
    "allowSyntheticDefaultImports": true,
    "sourceMap": true,
    "noEmit": true,
    "noEmitHelpers": true,
    "importHelpers": true,
    "strictNullChecks": true,
    "noImplicitAny": true,
    "noImplicitThis": true,
    "alwaysStrict": true,
    "removeComments": false,
    "typeRoots": [
      "node_modules/@types"
    ]
  },
  "exclude": [
    "node_modules",
    "public"
  ]
}
</code>
</pre>
</details>
<br />

**File**: `lib/transition/interface.d.ts`

------------------------

**Actual**:

![image](https://cloud.githubusercontent.com/assets/8445785/26728716/95a36ddc-47c4-11e7-8a41-aa75405943ad.png)
![image](https://cloud.githubusercontent.com/assets/8445785/26728729/a02e5dac-47c4-11e7-9d4a-dde3d5476f1b.png)


<details>
  <summary>TypeScript logs</summary>
<pre>
<code>
ERROR in [at-loader] ./node_modules/@uirouter/core/lib/transition/interface.d.ts:732:5
    TS2411: Property 'to' of type 'string | boolean | Predicate<StateDeclaration> | undefined' is not assignable to string index type 'string | boolean | Predicate<StateDeclaration>'.

ERROR in [at-loader] ./node_modules/@uirouter/core/lib/transition/interface.d.ts:734:5
    TS2411: Property 'from' of type 'string | boolean | Predicate<StateDeclaration> | undefined' is not assignable to string index type 'string | boolean | Predicate<StateDeclaration>'.

ERROR in [at-loader] ./node_modules/@uirouter/core/lib/transition/interface.d.ts:736:5
    TS2411: Property 'exiting' of type 'string | boolean | Predicate<StateDeclaration> | undefined' is not assignable to string index type 'string | boolean | Predicate<StateDeclaration>'.

ERROR in [at-loader] ./node_modules/@uirouter/core/lib/transition/interface.d.ts:738:5
    TS2411: Property 'retained' of type 'string | boolean | Predicate<StateDeclaration> | undefined' is not assignable to string index type 'string | boolean | Predicate<StateDeclaration>'.

ERROR in [at-loader] ./node_modules/@uirouter/core/lib/transition/interface.d.ts:740:5
    TS2411: Property 'entering' of type 'string | boolean | Predicate<StateDeclaration> | undefined' is not assignable to string index type 'string | boolean | Predicate<StateDeclaration>'.
</code>
</pre>
</details>

------------------------

**After patch**:

![image](https://cloud.githubusercontent.com/assets/8445785/26728755/bce4ab5e-47c4-11e7-8856-c28d6d5224a1.png)
![image](https://cloud.githubusercontent.com/assets/8445785/26728769/c5531abe-47c4-11e7-9b33-2dba49e06dc7.png)

