### PR TITLE
feat(urlMatcher): add support for multiline urls

### DIFF
--- a/src/url/urlMatcher.ts
+++ b/src/url/urlMatcher.ts
@@ -160,7 +160,7 @@ export class UrlMatcher {
     const matchDetails = (m: RegExpExecArray, isSearch: boolean) => {
       // IE[78] returns '' for unmatched groups instead of null
       let id = m[2] || m[3];
-      let regexp = isSearch ? m[4] : m[4] || (m[1] === '*' ? '.*' : null);
+      let regexp = isSearch ? m[4] : m[4] || (m[1] === '*' ? '[\\s\\S]*' : null);
 
       const makeRegexpType = (regexp) => inherit(paramTypes.type(isSearch ? "query" : "path"), {
         pattern: new RegExp(regexp, this.config.caseInsensitive ? 'i' : undefined)

--- a/test/urlMatcherFactorySpec.ts
+++ b/test/urlMatcherFactorySpec.ts
@@ -112,6 +112,15 @@ describe("UrlMatcher", function () {
       expect(m.exec('/document/', {})).toEqual({ path: '' });
     });
 
+    it("should capture catch-all parameters in multiline url", function () {
+      var m = $umf.compile('/document/*path');
+      expect(m.exec('/document/a/b/c\r\n/d', {})).toEqual({ path: 'a/b/c\r\n/d' });
+      expect(m.exec('/document/\r\na/b\r\n/c', {})).toEqual({ path: '\r\na/b\r\n/c' });
+      expect(m.exec('/document/a/b\r\n\r\n/c', {})).toEqual({ path: 'a/b\r\n\r\n/c' });
+      expect(m.exec('/document/a/\rb/c\n', {})).toEqual({ path: 'a/\rb/c\n' });
+      expect(m.exec('/document/\r\n', {})).toEqual({ path: '\r\n' });
+    });
+
     it("should use the optional regexp with curly brace placeholders", function () {
       var m = $umf.compile('/users/:id/details/{type}/{repeat:[0-9]+}?from&to');
       expect(m.exec('/users/123/details/what/thisShouldBeDigits', {})).toBeNull();


### PR DESCRIPTION
urls with \r or \n symbols in them (%0D or %0A when encoded) are matched with catch-all syntax

close angular-ui/ui-router#3432