### PR TITLE
docs(UrlRulesApi): Fix examples for `otherwise` and `initial`

### DIFF
--- a/src/url/interface.ts
+++ b/src/url/interface.ts
@@ -335,7 +335,7 @@ export interface UrlRulesApi {
    * #### Example:
    * When no other url rule matches, manually trigger a transition to the `home` state
    * ```js
-   * .otherwise((urlParts, router) => {
+   * .otherwise((matchValue, urlParts, router) => {
    *   router.stateService.go('home');
    * });
    * ```
@@ -343,7 +343,7 @@ export interface UrlRulesApi {
    * #### Example:
    * When no other url rule matches, go to `home` state
    * ```js
-   * .otherwise((urlParts, router) => {
+   * .otherwise((matchValue, urlParts, router) => {
    *   return { state: 'home' };
    * });
    * ```
@@ -379,7 +379,7 @@ export interface UrlRulesApi {
    * #### Example:
    * When no other url rule matches, go to `home` state
    * ```js
-   * .initial((url, router) => {
+   * .initial((matchValue, url, router) => {
    *   console.log('initial state');
    *   return { state: 'home' };
    * })


### PR DESCRIPTION
Hello,

This is a docs fix to make the `otherwise` and `initial` examples match the API.

The current examples show the handler functions accepting 2 arguments, but they're actually passed 3 arguments, and in a different order. See [plnkr](http://plnkr.co/edit/wQhzenbxnGrL0bll6Ptx?p=preview).

The [type information says](https://github.com/ui-router/core/blob/5.0.5/src/url/urlRouter.ts#L275) the handlers should be of type [UrlRuleHandlerFn](https://github.com/ui-router/core/blob/5.0.5/src/url/interface.ts#L461), which has 3 arguments. This led me to believe that the examples were wrong, rather than there being a bug in the implementation.

I believe the issue was introduced in [eb2f5d7](https://github.com/ui-router/core/commit/eb2f5d7#diff-d9320a28c4e21a9a0cc99c6bb2939878R322) and then copied in [bbe4209](https://github.com/ui-router/core/commit/bbe4209#diff-9466bef04ef1a9ae47481f9dc6565c47R346).