### PR TITLE
Use stable sorting when sorting routes

### DIFF
--- a/src/url/urlRouter.ts
+++ b/src/url/urlRouter.ts
@@ -87,12 +87,25 @@ export class UrlRouter implements UrlRulesApi, UrlSyncApi, Disposable {
 
   /** @inheritdoc */
   sort(compareFn?: (a: UrlRule, b: UrlRule) => number) {
-    this._rules.sort(this._sortFn = compareFn || this._sortFn);
+    this._rules = this.stableSort(this._rules, this._sortFn = compareFn || this._sortFn);
     this._sorted = true;
   }
 
   private ensureSorted() {
     this._sorted || this.sort();
+  }
+
+  private stableSort(arr, compareFn) {
+    const arrOfWrapper = arr.map((elem, idx) => ({ elem, idx }));
+
+    arrOfWrapper.sort((wrapperA, wrapperB) => {
+      const cmpDiff = compareFn(wrapperA.elem, wrapperB.elem);
+      return cmpDiff === 0
+        ? wrapperA.idx - wrapperB.idx
+        : cmpDiff;
+    });
+
+    return arrOfWrapper.map(wrapper => wrapper.elem);
   }
 
   /**


### PR DESCRIPTION
After a lot of research about what to use as a stable sorting algorithm, I found this to be the easiest, and it still uses `Array#sort` for good performance. I created the `stableSort` function in the same class, but if preferred I can move it.

Closes #66 