### PR TITLE
chore(typescript): Use primitive string type

### DIFF
--- a/src/state/targetState.ts
+++ b/src/state/targetState.ts
@@ -66,8 +66,8 @@ export class TargetState {
   }
 
   /** The name of the state this object targets */
-  name(): String {
-    return this._definition && this._definition.name || <String> this._identifier;
+  name(): string {
+    return this._definition && this._definition.name || <string> this._identifier;
   }
 
   /** The identifier used when creating this TargetState */


### PR DESCRIPTION
It is recommended to use the primitive `string` whenever possible.
This also fixes the issue of passing the return value of `targetState.name()` to a method that accepts a `string`, which currently requires one to cast from `String` to `string`.