### PR TITLE
Update PathUtils.treeChanges to retained nodes with to params applied

### DIFF
--- a/src/path/pathFactory.ts
+++ b/src/path/pathFactory.ts
@@ -135,7 +135,7 @@ export class PathUtils {
     entering              = toPath.slice(keep);
     to                    = (retainedWithToParams).concat(entering);
 
-    return { from, to, retained, exiting, entering };
+    return { from, to, retained: retainedWithToParams, exiting, entering };
   }
 
   /**


### PR DESCRIPTION
This is a patch to address an issue in sticky-states (https://github.com/ui-router/sticky-states/issues/13) where dynamic parameters were not working.

Updating PathUtils.treeChanges to return the retained nodes with the to parameters applied fixes the issue.