### PR TITLE
Fix string url params are not decoded

### DIFF
--- a/src/params/paramTypes.ts
+++ b/src/params/paramTypes.ts
@@ -270,7 +270,9 @@ function initDefaultTypes() {
 
   // Default Parameter Type Definitions
   extend(ParamTypes.prototype, {
-    string: makeDefaultType({}),
+    string: makeDefaultType({
+      decode: (val: any) => val != null ? decodeURIComponent(val.toString()) : val,
+    }),
 
     path: makeDefaultType({
       pattern: /[^/]*/,


### PR DESCRIPTION
String url params are not decoded when using direct links.

Steps to reproduce:
1. Having some string url param configured in state: f.e. "{query:string}"
2. Type in browser's address bar query param value with encoded chars: f.e. "?query=a%25b%25" (which equals to a%b% decoded)

Result: $stateParams.q === 'a%25b%25'
Expected: $stateParams.q === 'a%b%'

Note: ui-router encodes such values, but does not decode them back. The issue is reproduced event when you are setting such values through stateService.go() and then refreshing the page.