### PR TITLE
import 'isNullOrUndefined' from correct place

### DIFF
--- a/src/resolve/resolvable.ts
+++ b/src/resolve/resolvable.ts
@@ -13,7 +13,7 @@ import { isFunction, isObject } from '../common/predicates';
 import { Transition } from '../transition/transition';
 import { StateObject } from '../state/stateObject';
 import { PathNode } from '../path/pathNode';
-import { isNullOrUndefined } from '../common';
+import { isNullOrUndefined } from '../common/predicates';
 
 
 // TODO: explicitly make this user configurable


### PR DESCRIPTION
I ran into this error when creating an AngularJS/Angular hybrid app. After digging into the problem, I found that the function 'isNullOrUndefined' was actually defined in 'common/predicates' not 'common'
![image](https://user-images.githubusercontent.com/5322825/34691767-f04e3bf0-f47a-11e7-82db-77eb2bf6e807.png)
