### PR TITLE
Bugfix - stringify workaround for IE/Edge & undefined

### DIFF
--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -6,7 +6,7 @@
  * @module common_strings
  */ /** */
 
-import { isString, isArray, isDefined, isNull, isPromise, isInjectable, isObject } from './predicates';
+import { isString, isArray, isDefined, isUndefined, isNull, isPromise, isInjectable, isObject } from './predicates';
 import { Rejection } from '../transition/rejectFactory';
 import { IInjectable, identity, Obj, tail, pushR } from './common';
 import { pattern, is, not, val, invoke } from './hof';
@@ -106,6 +106,13 @@ export function stringify(o: any) {
       seen.push(value);
     }
     return stringifyPattern(value);
+  }
+
+  if (isUndefined(o)) {
+    // Workaround for IE & Edge Spec incompatibility where replacer function would not be called when JSON.stringify
+    // is given `undefined` as value. To work around that, we simply detect `undefined` and bail out early by
+    // manually stringifying it.
+    return format(o);
   }
 
   return JSON.stringify(o, (key, value) => format(value)).replace(/\\"/g, '"');


### PR DESCRIPTION
A typical edge (did they name the browser according to this 🤔) case in IE & Edge land - a difference in how `undefined` value is handled in `JSON.stringify` with replacer specified. For example, here's behavior in Chrome:
![screen shot 2018-05-25 at 9 34 23 am](https://user-images.githubusercontent.com/1277553/40530215-8cdff260-6000-11e8-897a-1c00fd07b0c2.png)

However, IE11 has quite a different mindset:
![screen shot 2018-05-25 at 9 31 54 am](https://user-images.githubusercontent.com/1277553/40530230-99ba39e6-6000-11e8-9527-d5ecc6d68f24.png)


Notice that `console.log` wasn't called in IE version of the script - that caused a bug in the `stringify` function as well - `JSON.stringify` would return `undefined`, on which we'd then call `.replace` and obviously fail.


**Code to reproduce**
```js
JSON.stringify(undefined, console.log); // console.log should log output in browsers which follow spec.
```