### PR TITLE
Add 'module' entry to allow Webpack to tree shake it

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "typings": "lib/index.d.ts",
   "main": "lib/index.js",
   "jsnext:main": "lib-esm/index.js",
+  "module": "lib-esm/index.js",
   "license": "MIT",
   "devDependencies": {
     "@types/jasmine": "^2.8.8",


### PR DESCRIPTION
Bundlers such as Webpack are not support `jsnext:main` entry, but do support `module`.

I've just added that entry, I've checked on my build, and webpack was able to enable module concat optimisation and tree shaking.