### PR TITLE
Pass in transition to HookMatchCriteria

### DIFF
--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -32,6 +32,7 @@ export interface TypedMap<T> {
   [key: string]: T;
 }
 export type Predicate<X> = (x?: X) => boolean;
+export type PredicateBinary<X, Y> = (x?: X, y?: Y) => boolean;
 /**
  * An ng1-style injectable
  *

--- a/src/transition/hookBuilder.ts
+++ b/src/transition/hookBuilder.ts
@@ -60,7 +60,7 @@ export class HookBuilder {
     const treeChanges = transition.treeChanges();
 
     // Find all the matching registered hooks for a given hook type
-    const matchingHooks = this.getMatchingHooks(hookType, treeChanges);
+    const matchingHooks = this.getMatchingHooks(hookType, treeChanges, transition);
     if (!matchingHooks) return [];
 
     const baseHookOptions = <TransitionHookOptions>{
@@ -70,7 +70,7 @@ export class HookBuilder {
 
     const makeTransitionHooks = (hook: RegisteredHook) => {
       // Fetch the Nodes that caused this hook to match.
-      const matches: IMatchingNodes = hook.matches(treeChanges);
+      const matches: IMatchingNodes = hook.matches(treeChanges, transition);
       // Select the PathNode[] that will be used as TransitionHook context objects
       const matchingNodes: PathNode[] = matches[hookType.criteriaMatchPath.name];
 
@@ -108,7 +108,11 @@ export class HookBuilder {
    *
    * @returns an array of matched [[RegisteredHook]]s
    */
-  public getMatchingHooks(hookType: TransitionEventType, treeChanges: TreeChanges): RegisteredHook[] {
+  public getMatchingHooks(
+    hookType: TransitionEventType,
+    treeChanges: TreeChanges,
+    transition: Transition
+  ): RegisteredHook[] {
     const isCreate = hookType.hookPhase === TransitionHookPhase.CREATE;
 
     // Instance and Global hook registries
@@ -119,7 +123,7 @@ export class HookBuilder {
       .map((reg: IHookRegistry) => reg.getHooks(hookType.name)) // Get named hooks from registries
       .filter(assertPredicate(isArray, `broken event named: ${hookType.name}`)) // Sanity check
       .reduce(unnestR, []) // Un-nest RegisteredHook[][] to RegisteredHook[] array
-      .filter(hook => hook.matches(treeChanges)); // Only those satisfying matchCriteria
+      .filter(hook => hook.matches(treeChanges, transition)); // Only those satisfying matchCriteria
   }
 }
 

--- a/src/transition/interface.ts
+++ b/src/transition/interface.ts
@@ -1,6 +1,6 @@
 /** @publicapi @module transition */ /** */
 import { StateDeclaration } from '../state/interface';
-import { Predicate } from '../common/common';
+import { PredicateBinary } from '../common/common';
 
 import { Transition } from './transition';
 import { StateObject } from '../state/stateObject';
@@ -716,8 +716,8 @@ export interface IHookRegistry {
   getHooks(hookName: string): RegisteredHook[];
 }
 
-/** A predicate type which tests if a [[StateObject]] passes some test. Returns a boolean. */
-export type IStateMatch = Predicate<StateObject>;
+/** A predicate type which tests if a [[StateObject]] and [[Transition]] passes some test. Returns a boolean. */
+export type IStateMatch = PredicateBinary<StateObject, Transition>;
 
 /**
  * This object is used to configure whether or not a Transition Hook is invoked for a particular transition,
@@ -763,6 +763,14 @@ export type IStateMatch = Predicate<StateObject>;
  *   to: function(state) {
  *     return state.data != null && state.data.authRequired === true;
  *   }
+ * }
+ * ```
+ * #### Example:
+ * ```js
+ * // This will match when route is just entered (initial load) or when the state is hard-refreshed
+ * // by specifying `{refresh: true}` as transition options.
+ * var match = {
+ *   from: (state, transition) => state.self.name === '' || transition.options().reload
  * }
  * ```
  *
@@ -826,7 +834,7 @@ export interface PathType {
  *
  * A [[Glob]] string that matches the name of a state.
  *
- * Or, a function with the signature `function(state) { return matches; }`
+ * Or, a function with the signature `function(state, transition) { return matches; }`
  * which should return a boolean to indicate if a state matches.
  *
  * Or, `true` to always match

--- a/src/transition/transition.ts
+++ b/src/transition/transition.ts
@@ -247,8 +247,8 @@ export class Transition implements IHookRegistry {
       return this.is({ to: compare.$to().name, from: compare.$from().name });
     }
     return !(
-      (compare.to && !matchState(this.$to(), compare.to)) ||
-      (compare.from && !matchState(this.$from(), compare.from))
+      (compare.to && !matchState(this.$to(), compare.to, this)) ||
+      (compare.from && !matchState(this.$from(), compare.from, this))
     );
   }
 


### PR DESCRIPTION
This allows the matcher functions to access the raw transition object. Doing so unlocks a bit more flexibility, as some of the matching could be performed using the transition object. For example:

```js
$transitions.onBefore({
  from: (state, transition) => state.self.name === '' || transition.options().reload
}, (transition) => {
  //...
});
```

The above will run only when coming from the root state (i.e. initial page load), **or** (and that's not possible today) if the `{reload: true}` option was used when navigating to a state.