### PR TITLE
fix(lazyLoad): StateBuilder should not mutate the state declaration

### DIFF
--- a/test/lazyLoadSpec.ts
+++ b/test/lazyLoadSpec.ts
@@ -53,6 +53,12 @@ describe('future state', function() {
       expect($registry.get(state)).toBe(statedef);
     });
 
+    it('should not change the url of future states', () => {
+      const statedef = { name: 'future.**', url: '/future' };
+      const state = $registry.register(statedef);
+      expect($registry.get(state).url).toBe('/future');
+    });
+
     it('should replace a future state when a normal state of the same name is registered', () => {
       const state = $registry.register({ name: 'future.**' });
 


### PR DESCRIPTION
Fixed repeated {remainder:any} params error when future state is registered repeatedly. This scenario is typically happened during unit test.

Related: https://github.com/ui-router/core/commit/3cd5a2a#r31260154