### PR TITLE
Fix base href for non http/https protocols

### DIFF
--- a/src/vanilla/browserLocationConfig.ts
+++ b/src/vanilla/browserLocationConfig.ts
@@ -44,7 +44,7 @@ export class BrowserLocationConfig implements LocationConfig {
   private getBaseHref() {
     const baseTag: HTMLBaseElement = document.getElementsByTagName('base')[0];
     if (baseTag && baseTag.href) {
-      return baseTag.href.replace(/^(https?:)?\/\/[^/]*/, '');
+      return new URL(baseTag.href).pathname;
     }
 
     return this._isHtml5 ? '/' : location.pathname || '/';


### PR DESCRIPTION
Base href is incorrect for Google Chrome extensions.

Expected: "/baseHref/"
Result: "chrome-extension://cckppebifaokhmbkciccdindfbmacjcj/baseHref/"

Fixed getBaseHref function:
return new URL(baseTag.href).pathname instead  return baseTag.href.replace(/^(https?:)?\/\/[^/]*/, '')