### PR TITLE
fix(typescript): Mark `params` as optional in StateService.href

### DIFF
--- a/src/state/stateService.ts
+++ b/src/state/stateService.ts
@@ -500,7 +500,7 @@ export class StateService {
    *
    * @returns {string} compiled state url
    */
-  href(stateOrName: StateOrName, params: RawParams, options?: HrefOptions): string {
+  href(stateOrName: StateOrName, params?: RawParams, options?: HrefOptions): string {
     const defaultHrefOpts = {
       lossy: true,
       inherit: true,


### PR DESCRIPTION
Closes #287