### PR TITLE
Fix error when `strictNullChecks: true`

### DIFF
--- a/src/transition/interface.ts
+++ b/src/transition/interface.ts
@@ -118,7 +118,7 @@ export interface TransitionHookOptions {
  */
 export interface TreeChanges {
   /** @nodoc */
-  [key: string]: PathNode[];
+  [key: string]: PathNode[] | undefined;
 
   /** The path of nodes in the state tree that the transition is coming *from* */
   from: PathNode[];


### PR DESCRIPTION
With TypeScript's `strictNullChecks` set to `true`, I receive the following errors:

```
Property 'inactivating' of type 'PathNode[] | undefined' is not assignable to string index type 'PathNode[]'.ts(2411)
Property 'reactivating' of type 'PathNode[] | undefined' is not assignable to string index type 'PathNode[]'.ts(2411)
```

The following change fixes the error.