### PR TITLE
chore(package): Adding pkg.browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "typings": "lib/index.d.ts",
   "main": "lib/index.js",
+  "browser": "lib/index.js",
   "jsnext:main": "lib-esm/index.js",
   "module": "lib-esm/index.js",
   "license": "MIT",


### PR DESCRIPTION
package.json browser is recommended used for client side scripts .
https://docs.npmjs.com/cli/v7/configuring-npm/package-json#browser

Some module bundles like webpack use browser> module> main to resolve the modules according to the target ,
not having a browser field in the package.json, it always solves the pkg.module, this is a problem when you want to load browser modules that have things like windows and / or no imports (they are not supported in iifes)